### PR TITLE
transparent hole fix

### DIFF
--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/FastTravelScreen.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/FastTravelScreen.java
@@ -22,24 +22,19 @@ public class FastTravelScreen extends ModernWarpScreen{
 
     @Override
     protected void warpButtonHandler(WarpButton button) {
-        // Don't send command twice for single warp islands
         if (Util.getMillis() > this.warpFailCoolDownExpiryTime) {
-            if (button.getIsland().warpList.size() > 1) {
-                String warpCommand = button.getWarpCommand();
-                if (Minecraft.getInstance().player != null)
-                    Minecraft.getInstance().player.connection.sendCommand(warpCommand.substring(1));
-            }
+            String warpCommand = button.getWarpCommand();
+            if (Minecraft.getInstance().player != null)
+                Minecraft.getInstance().player.connection.sendCommand(warpCommand.substring(1));
         }
     }
 
     @Override
     protected void islandButtonHandler(IslandButton button) {
         if (Util.getMillis() > this.warpFailCoolDownExpiryTime) {
-            if (button.island.warpList.size() == 1) {
-                String warpCommand = button.island.warpList.getFirst().getWarpCommand();
-                if (Minecraft.getInstance().player != null)
-                    Minecraft.getInstance().player.connection.sendCommand(warpCommand.substring(1));
-            }
+            String warpCommand = button.island.warpList.getFirst().getWarpCommand();
+            if (Minecraft.getInstance().player != null)
+                Minecraft.getInstance().player.connection.sendCommand(warpCommand.substring(1));
         }
     }
 

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/ModernWarpScreen.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/ModernWarpScreen.java
@@ -153,17 +153,15 @@ public class ModernWarpScreen extends CustomContainerScreen{
     }
 
     protected void addIslandButton(Island island) {
-        IslandButton button = new IslandButton(this, this.window, island,
-                islandButton -> this.islandButtonHandler((IslandButton) islandButton), Supplier::get);
-        if (island.warpList.size() == 1){
+        if (!island.warpList.isEmpty()) {
+            IslandButton button = new IslandButton(this, this.window, island,
+                    islandButton -> this.islandButtonHandler((IslandButton) islandButton), Supplier::get);
             this.addRenderableWidget(button);
-        }
-        for (Warp warp : island.warpList) {
-            this.addRenderableWidget(new WarpButton(button, warp,
-                    warpButton -> this.warpButtonHandler((WarpButton) warpButton), Supplier::get));
-        }
-        if (island.warpList.size() > 1) {
-            this.addRenderableWidget(button);
+
+            for (Warp warp : island.warpList) {
+                this.addRenderableWidget(new WarpButton(button, warp,
+                        warpButton -> this.warpButtonHandler((WarpButton) warpButton), Supplier::get));
+            }
         }
     }
 
@@ -526,7 +524,7 @@ public class ModernWarpScreen extends CustomContainerScreen{
     protected boolean customUIMouseClicked(double mouseX, double mouseY, int button) {
         // Left click
         if (button == InputConstants.MOUSE_BUTTON_LEFT) {
-            for (GuiEventListener listener : this.children()) {
+            for (GuiEventListener listener : this.children().reversed()) {
                 if (listener instanceof CustomContainerButton) {
                     if (listener.mouseClicked(mouseX, mouseY, button)) {
                         break;

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/RiftFastTravelScreen.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/RiftFastTravelScreen.java
@@ -20,19 +20,14 @@ public class RiftFastTravelScreen extends ModernWarpScreen{
     @Override
     protected void warpButtonHandler(WarpButton button) {
         if (Util.getMillis() > this.warpFailCoolDownExpiryTime) {
-            // Don't click twice for islands with only one warp
-            if (button.getIsland().warpList.size() > 1) {
-                clickSlot(button.getWarpSlotIndex());
-            }
+            clickSlot(button.getWarpSlotIndex());
         }
     }
 
     @Override
     protected void islandButtonHandler(IslandButton button) {
         if (Util.getMillis() > this.warpFailCoolDownExpiryTime) {
-            if (button.island.warpList.size() == 1) {
-                clickSlot(button.island.warpList.getFirst().slotIndex());
-            }
+            clickSlot(button.island.warpList.getFirst().slotIndex());
         }
     }
 }


### PR DESCRIPTION
Due to the rendering, the portal texture would remove parts of the island texture.
![ModernWarpMenuScreen](https://github.com/user-attachments/assets/007b5b23-24a7-4a98-aa2d-ef2b1aa46a97)

I changed rendering order and reversed the click priority to account for that change.

I tested the code and found no instances of the warp being sent twice.