### PR TITLE
Updated mod to 1.21.6+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings loom.layered(){
 		officialMojangMappings()
-		parchment("org.parchmentmc.data:parchment-1.21.5:2025.06.15@zip")
+		parchment("org.parchmentmc.data:parchment-1.21.6:2025.06.29@zip")
 	}
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@ fabric_version=0.128.2+1.21.6
 architectury_version=17.0.6
 yacl_version=3.7.1+1.21.6-fabric
 modmenu_version=15.0.0-beta.3
-rei_version=19.0.809
+rei_version=20.0.810
 skyblocker_version=v5.5.0+1.21.5
 conditional_mixin_version=0.6.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,19 +4,19 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.5
+minecraft_version=1.21.6
 loader_version=0.16.14
 
 # Mod Properties
-mod_version=0.1.3+1.21.5
+mod_version=0.1.3+1.21.6
 maven_group=com.github.yukkuritaku.modernwarpmenu
 archives_base_name=modernwarpmenu
 
 # Dependencies
-fabric_version=0.128.1+1.21.5
-architectury_version=16.1.4
-yacl_version=3.7.1+1.21.5-fabric
-modmenu_version=14.0.0-rc.2
+fabric_version=0.128.2+1.21.6
+architectury_version=17.0.6
+yacl_version=3.7.1+1.21.6-fabric
+modmenu_version=15.0.0-beta.3
 rei_version=19.0.809
 skyblocker_version=v5.5.0+1.21.5
 conditional_mixin_version=0.6.3

--- a/src/main/generated/.cache/41d5e88dedd0e67845cfc719faf7b369a3afd99b
+++ b/src/main/generated/.cache/41d5e88dedd0e67845cfc719faf7b369a3afd99b
@@ -1,3 +1,3 @@
-// 1.21.5	-999999999-01-01T00:00:00	Modern Warp Menu/layouts
-d1a58dd0c3cc633b2f338c100ace5f6c37cd7739 assets/modernwarpmenu/layouts/layout.json
+// 1.21.6	-999999999-01-01T00:00:00	Modern Warp Menu/layouts
+274dbb22cad9263240a17eaca67736e4fd4f316c assets/modernwarpmenu/layouts/layout.json
 a46889675870b5d7f333a3417c430a6e707896bc assets/modernwarpmenu/layouts/rift_layout.json

--- a/src/main/generated/.cache/9fa017f27a5858cd7b272927da7d3125da472929
+++ b/src/main/generated/.cache/9fa017f27a5858cd7b272927da7d3125da472929
@@ -1,2 +1,2 @@
-// 1.21.5	-999999999-01-01T00:00:00	Modern Warp Menu/constants
+// 1.21.6	-999999999-01-01T00:00:00	Modern Warp Menu/constants
 2717ca5bd4b875207d1cf4559426f9f4cb9f461f assets/modernwarpmenu/constants/skyblock_constants.json

--- a/src/main/generated/assets/modernwarpmenu/layouts/layout.json
+++ b/src/main/generated/assets/modernwarpmenu/layouts/layout.json
@@ -185,20 +185,20 @@
         {
           "command_name": "end",
           "display_name": "Spawn",
-          "grid_x": 26,
-          "grid_y": 20
+          "grid_x": 27,
+          "grid_y": 18
         },
         {
           "command_name": "drag",
           "display_name": "Nest",
           "grid_x": 11,
-          "grid_y": 32
+          "grid_y": 30
         },
         {
           "command_name": "void",
           "display_name": "Void",
           "grid_x": 24,
-          "grid_y": 30
+          "grid_y": 28
         }
       ],
       "width_percentage": 0.15,

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/components/ScaleTransitionButton.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/components/ScaleTransitionButton.java
@@ -14,6 +14,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ARGB;
 import net.minecraft.util.Mth;
+import org.joml.Matrix3x2fStack;
 import org.joml.Matrix4f;
 
 import java.awt.*;
@@ -39,7 +40,7 @@ public class ScaleTransitionButton extends CustomContainerButton{
      */
     public void calculateHoverState(int mouseX, int mouseY) {
         this.isHovered =
-                        mouseX >= this.scaledXPosition &&
+                mouseX >= this.scaledXPosition &&
                         mouseY >= this.scaledYPosition &&
                         mouseX <= this.scaledXPosition + this.scaledWidth &&
                         mouseY <= this.scaledYPosition + this.scaledHeight;
@@ -70,15 +71,15 @@ public class ScaleTransitionButton extends CustomContainerButton{
      *
      * @param color color of the border
      */
-    public void renderBorder(GuiGraphics guiGraphics, int color){
-        PoseStack stack = guiGraphics.pose();
-        stack.pushPose();
-        stack.translate(0, 0, this.getZLevel());
+    public void renderBorder(GuiGraphics guiGraphics, int color) {
+        Matrix3x2fStack stack = guiGraphics.pose();
+        stack.pushMatrix();
+        stack.translate(0, 0); // z is ignored in 2D
         guiGraphics.hLine((int) this.scaledXPosition, (int) (this.scaledXPosition + this.scaledWidth), (int) this.scaledYPosition, color);
         guiGraphics.vLine((int) this.scaledXPosition, (int) this.scaledYPosition, (int) (this.scaledYPosition + this.scaledHeight), color);
         guiGraphics.hLine((int) this.scaledXPosition, (int) (this.scaledXPosition + this.scaledWidth), (int) (this.scaledYPosition + this.scaledHeight), color);
         guiGraphics.vLine((int) (this.scaledXPosition + this.scaledWidth), (int) this.scaledYPosition, (int) (this.scaledYPosition + this.scaledHeight), color);
-        stack.popPose();
+        stack.popMatrix();
     }
     /**
      * Draws the provided texture at ({@code this.scaledXPosition}, {@code this.scaledYPosition}, {@code this.zLevel}) at a size of ({@code this.scaledWidth})x({@code this.scaledHeight})
@@ -86,21 +87,25 @@ public class ScaleTransitionButton extends CustomContainerButton{
      * @param texture location of texture to draw
      */
     protected void renderButtonTexture(GuiGraphics guiGraphics, ResourceLocation texture) {
-        PoseStack stack = guiGraphics.pose();
-        Matrix4f pose = stack.last().pose();
         int color;
-        if (this.isHovered){
+        if (this.isHovered) {
             color = new Color(HOVERED_BRIGHTNESS, HOVERED_BRIGHTNESS, HOVERED_BRIGHTNESS, 1f).getRGB();
-        }else {
+        } else {
             color = new Color(UN_HOVERED_BRIGHTNESS, UN_HOVERED_BRIGHTNESS, UN_HOVERED_BRIGHTNESS, 1f).getRGB();
         }
-        guiGraphics.drawSpecial(multiBufferSource -> {
-            VertexConsumer consumer = multiBufferSource.getBuffer(RenderType.guiTextured(texture));
-            consumer.addVertex(pose, this.scaledXPosition, this.scaledYPosition + this.scaledHeight, this.getZLevel()).setUv(0, 1).setColor(color);
-            consumer.addVertex(pose, this.scaledXPosition + this.scaledWidth, this.scaledYPosition + this.scaledHeight, this.getZLevel()).setUv(1, 1).setColor(color);
-            consumer.addVertex(pose, this.scaledXPosition + this.scaledWidth, this.scaledYPosition, this.getZLevel()).setUv(1, 0).setColor(color);
-            consumer.addVertex(pose, this.scaledXPosition, this.scaledYPosition, this.getZLevel()).setUv(0, 0).setColor(color);
-        });
+        // Draw the texture using the new pipeline
+        guiGraphics.blit(
+                net.minecraft.client.renderer.RenderPipelines.GUI_TEXTURED,
+                texture,
+                (int) this.scaledXPosition,
+                (int) this.scaledYPosition,
+                0.0F, 0.0F, // u, v
+                (int) this.scaledWidth,
+                (int) this.scaledHeight,
+                (int) this.scaledWidth,
+                (int) this.scaledHeight,
+                color
+        );
     }
 
 
@@ -115,7 +120,7 @@ public class ScaleTransitionButton extends CustomContainerButton{
     public void renderMessageString(GuiGraphics guiGraphics, float xOffset, float yOffset, Color textColor) {
 
         String[] lines = this.getMessage().getString().split("\n");
-        PoseStack stack = guiGraphics.pose();
+        Matrix3x2fStack stack = guiGraphics.pose();
         Color color;
         if (this.isHovered){
             color = new Color((int) (textColor.getRed() * HOVERED_BRIGHTNESS),
@@ -127,13 +132,13 @@ public class ScaleTransitionButton extends CustomContainerButton{
                     (int) (textColor.getGreen() * UN_HOVERED_BRIGHTNESS),
                     (int) (textColor.getBlue() * UN_HOVERED_BRIGHTNESS), 255);
         }
-        stack.pushPose();
-        stack.translate(this.scaledXPosition + xOffset, this.scaledYPosition + yOffset, this.getZLevel() + 1);
-        stack.scale(this.transition.getCurrentScale(), this.transition.getCurrentScale(), 1);
+        stack.pushMatrix();
+        stack.translate(this.scaledXPosition + xOffset, this.scaledYPosition + yOffset);
+        stack.scale(this.transition.getCurrentScale(), this.transition.getCurrentScale());
         for (int i = 0; i < lines.length; i++) {
             guiGraphics.drawCenteredString(Minecraft.getInstance().font, lines[i], 0, Minecraft.getInstance().font.lineHeight * i, color.getRGB());
         }
-        stack.popPose();
+        stack.popMatrix();
     }
 
     protected void renderForegroundLayer(GuiGraphics guiGraphics, ResourceLocation foregroundTexture){
@@ -146,7 +151,14 @@ public class ScaleTransitionButton extends CustomContainerButton{
     public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         if (this.visible) {
             this.renderWidget(guiGraphics, mouseX, mouseY, partialTick);
-            this.tooltip.refreshTooltipForNextRenderPass(this.isHovered(), this.isFocused(), this.getRectangle());
+            this.tooltip.refreshTooltipForNextRenderPass(
+                    guiGraphics,
+                    mouseX,
+                    mouseY,
+                    this.isHovered(),
+                    this.isFocused(),
+                    this.getRectangle()
+            );
         }
     }
 

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/components/ScaleTransitionButton.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/components/ScaleTransitionButton.java
@@ -4,18 +4,12 @@ import com.github.yukkuritaku.modernwarpmenu.client.gui.screens.grid.GridRectang
 import com.github.yukkuritaku.modernwarpmenu.client.gui.screens.transition.ScaleTransition;
 import com.github.yukkuritaku.modernwarpmenu.data.layout.texture.LayoutTexture;
 import com.github.yukkuritaku.modernwarpmenu.data.settings.SettingsManager;
-import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexConsumer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ARGB;
-import net.minecraft.util.Mth;
 import org.joml.Matrix3x2fStack;
-import org.joml.Matrix4f;
 
 import java.awt.*;
 

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/ModernWarpScreen.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/ModernWarpScreen.java
@@ -26,6 +26,8 @@ import net.minecraft.client.gui.components.MultiLineTextWidget;
 import net.minecraft.client.gui.components.Renderable;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.font.TextFieldHelper;
+import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.client.gui.screens.inventory.tooltip.DefaultTooltipPositioner;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.ARGB;
 import net.minecraft.world.Container;
@@ -35,6 +37,7 @@ import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.joml.Matrix3x2fStack;
 import org.slf4j.Logger;
 
 import java.awt.*;
@@ -136,12 +139,12 @@ public class ModernWarpScreen extends CustomContainerScreen{
     public void drawExceptionScreen(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
         renderBackground(guiGraphics, mouseX, mouseY, partialTick);
         // Labels are under the background for some reason
-        guiGraphics.pose().pushPose();
-        guiGraphics.pose().translate(0, 0, 1);
+        guiGraphics.pose().pushMatrix();
+        guiGraphics.pose().translate(0, 0);
         for (Renderable renderable : ((ScreenAccessor)this).getRenderables()){
             renderable.render(guiGraphics, mouseX, mouseY, partialTick);
         }
-        guiGraphics.pose().popPose();
+        guiGraphics.pose().popMatrix();
         for (GuiEventListener listener : this.children()){
             ((Button)listener).render(guiGraphics, mouseX, mouseY, partialTick);
         }
@@ -214,12 +217,21 @@ public class ModernWarpScreen extends CustomContainerScreen{
                                     int zLevel) {
         debugStrings.add(Component.literal("gridX: " + nearestGridX));
         debugStrings.add(Component.literal("gridY: " + nearestGridY));
-        // zLevel of -1 means z is not relevant, like in the case of screen coordinates
         if (zLevel > -1) {
             debugStrings.add(Component.literal("zLevel: " + zLevel));
         }
-        guiGraphics.renderTooltip(Minecraft.getInstance().font, debugStrings,
-                Optional.empty(), drawX, drawY);
+        // Convert to ClientTooltipComponent
+        List<ClientTooltipComponent> tooltipComponents = debugStrings.stream()
+                .map(c -> ClientTooltipComponent.create(c.getVisualOrderText()))
+                .toList();
+        guiGraphics.renderTooltip(
+                Minecraft.getInstance().font,
+                tooltipComponents,
+                drawX,
+                drawY,
+                DefaultTooltipPositioner.INSTANCE,
+                null
+        );
         guiGraphics.fill(drawX - 2, drawY - 2, drawX + 2, drawY + 2, Color.RED.getRGB());
     }
 
@@ -416,7 +428,17 @@ public class ModernWarpScreen extends CustomContainerScreen{
         renderButtons(guiGraphics, mouseX, mouseY, partialTick);
         // Draw warp fail tooltip
         if (Util.getMillis() <= warpFailTooltipExpiryTime && warpFailMessage != null) {
-            guiGraphics.renderTooltip(Minecraft.getInstance().font, this.warpFailMessage, mouseX, mouseY);
+            List<ClientTooltipComponent> tooltipComponents = List.of(
+                    ClientTooltipComponent.create(warpFailMessage.getVisualOrderText())
+            );
+            guiGraphics.renderTooltip(
+                    Minecraft.getInstance().font,
+                    tooltipComponents,
+                    mouseX,
+                    mouseY,
+                    DefaultTooltipPositioner.INSTANCE,
+                    null
+            );
         }
 
         if (SettingsManager.get().debug.debugModeEnabled && SettingsManager.get().debug.showDebugOverlay) {
@@ -426,8 +448,8 @@ public class ModernWarpScreen extends CustomContainerScreen{
             int nearestX;
             int nearestY;
             boolean tooltipDrawn = false;
-            guiGraphics.pose().pushPose();
-            guiGraphics.pose().translate(0, 0, 20);
+            guiGraphics.pose().pushMatrix();
+            guiGraphics.pose().translate(0, 0);
             // Draw screen resolution
             guiGraphics.drawCenteredString(Minecraft.getInstance().font,
                     String.format("%d x %d (%d)",
@@ -465,7 +487,7 @@ public class ModernWarpScreen extends CustomContainerScreen{
                 drawY = (int) this.grid.getActualY(nearestY);
                 renderDebugStrings(guiGraphics, debugMessages, drawX, drawY, nearestX, nearestY, -1);
             }
-            guiGraphics.pose().popPose();
+            guiGraphics.pose().popMatrix();
         }
     }
 

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/ModernWarpScreen.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/client/gui/screens/ModernWarpScreen.java
@@ -37,13 +37,11 @@ import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.joml.Matrix3x2fStack;
 import org.slf4j.Logger;
 
 import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/data/layout/LayoutProvider.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/data/layout/LayoutProvider.java
@@ -90,9 +90,9 @@ public class LayoutProvider implements DataProvider {
                                         "textures/gui/islands/end.png"), 707, 667),
                                 2, 2, 2, 0.15f,
                                 List.of(
-                                        new Warp(26, 20, "Spawn", "end"),
-                                        new Warp(11, 32, "Nest", "drag"),
-                                        new Warp(24, 30, "Void", "void")
+                                        new Warp(27, 18, "Spawn", "end"),
+                                        new Warp(11, 30, "Nest", "drag"),
+                                        new Warp(24, 28, "Void", "void")
                                 )
                         ),
                         new Island("Gold Mine",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,7 +37,7 @@
 	"accessWidener": "modernwarpmenu.accesswidener",
 	"depends": {
 		"fabricloader": ">=0.16.9",
-		"minecraft": "~1.21.5",
+		"minecraft": "~1.21.6",
 		"java": ">=21",
 		"fabric-api": "*",
 		"yet_another_config_lib_v3": "*"


### PR DESCRIPTION
### Summary

- Updated the mod to support Minecraft **1.21.6**, **1.21.7**, and **1.21.8**
- Small tweak to the **End** warp icon position so the **Nest** warp doesn't overlap as much with the **The End** text

### Note

If you could credit me as **Kd_Gaming1** instead of **KdGaming0**, would that be great. That’s the username I use everywhere else.
