### PR TITLE
Add SkyBlock Item List compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ repositories {
 		url = 'https://maven.parchmentmc.org'
 	}
 	maven { url "https://maven.shedaniel.me" }
+    maven { url 'https://maven.operationpotato.com/snapshots' }
 
 	//conditional-mixin https://github.com/Fallen-Breath/conditional-mixin
 	maven { url 'https://maven.fallenbreath.me/releases' }
@@ -83,6 +84,7 @@ dependencies {
 	implementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 	compileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}"
 	compileOnly "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
+    compileOnly "com.operationpotato:skyblock-item-list-api:${project.itemlist_version}"
 	compileOnly "maven.modrinth:skyblocker-liap:${project.skyblocker_version}"
 	include(implementation("me.fallenbreath:conditional-mixin-fabric:${project.conditional_mixin_version}"))
 	//include(implementation("net.hypixel:mod-api:${project.hypixel_mod_api_version}"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,4 @@ skyblocker_version=v6.5.0+26.1.2
 conditional_mixin_version=0.6.4
 hypixel_mod_api_version=1.0.1
 hm_api_version=1.0.3+26.1
+itemlist_version=0.0.5+26.1.2-SNAPSHOT

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/compat/itemlist/ItemListPluginImpl.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/compat/itemlist/ItemListPluginImpl.java
@@ -1,0 +1,25 @@
+package com.github.yukkuritaku.modernwarpmenu.compat.itemlist;
+
+import com.github.yukkuritaku.modernwarpmenu.ModernWarpMenu;
+import com.github.yukkuritaku.modernwarpmenu.state.ModernWarpMenuState;
+import com.operationpotato.itemlist.api.ExcludedScreensManager;
+import com.operationpotato.itemlist.api.Plugin;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.gui.screens.inventory.ContainerScreen;
+
+import java.util.Optional;
+
+public class ItemListPluginImpl implements Plugin
+{
+    private static final String MOD_NAME = FabricLoader.getInstance()
+        .getModContainer(ModernWarpMenu.MOD_ID)
+        .orElseThrow()
+        .getMetadata()
+        .getName();
+    
+    @Override
+    public void registerExcludedScreens(ExcludedScreensManager excludedScreensManager) {
+        excludedScreensManager.addProvider(ContainerScreen.class, _ ->
+            ModernWarpMenuState.isModernWarpMenuOpen() ? Optional.of(MOD_NAME) : Optional.empty());
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,6 +23,9 @@
 		"modmenu": [
 			"com.github.yukkuritaku.modernwarpmenu.compat.modmenu.ModMenuApiImpl"
 		],
+        "skyblock-item-list": [
+            "com.github.yukkuritaku.modernwarpmenu.compat.itemlist.ItemListPluginImpl"
+        ],
 		"fabric-datagen": [
 			"com.github.yukkuritaku.modernwarpmenu.ModernWarpMenuDataGenerator"
 		],


### PR DESCRIPTION
[SkyBlock Item List](https://github.com/OperationPotato/ItemList) is an item list mod (similar to REI or JEI) that is specifically made for Hypixel SkyBlock.

This PR adds compatibility with the mod to hide the item list panel when the warp menu is open.