### PR TITLE
I fixed the other files that were blocking the 26.2 migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ repositories {
 		url = 'https://maven.parchmentmc.org'
 	}
 	maven { url "https://maven.shedaniel.me" }
-    maven { url 'https://maven.operationpotato.com/snapshots' }
+    maven { url 'https://maven.operationpotato.com/releases' }
 
 	//conditional-mixin https://github.com/Fallen-Breath/conditional-mixin
 	maven { url 'https://maven.fallenbreath.me/releases' }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,23 +7,23 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1.2
+minecraft_version=26.2
 loader_version=0.19.2
 loom_version=1.16-SNAPSHOT
 
 # Mod Properties
-mod_version=0.2.3+26.1.2
+mod_version=0.2.4+26.2
 maven_group=com.github.yukkuritaku.modernwarpmenu
 archives_base_name=modernwarpmenu
 
 # Dependencies
-fabric_version=0.150.0+26.1.2
-architectury_version=19.0.1
-yacl_version=3.9.3+26.1-fabric
-modmenu_version=18.0.0-beta.1
-rei_version=21.11.814
-skyblocker_version=v6.5.0+26.1.2
+fabric_version=0.154.0+26.2
+architectury_version=21.0.2
+yacl_version=3.9.5+26.2-fabric
+modmenu_version=20.0.0-beta.4
+rei_version=26.2.820
+skyblocker_version=v6.6.0+26.2
 conditional_mixin_version=0.6.4
-hypixel_mod_api_version=1.0.1
-hm_api_version=1.0.3+26.1
-itemlist_version=0.0.5+26.1.2-SNAPSHOT
+hypixel_mod_api_version=1.0.2+build.1+mc26.1
+hm_api_version=1.0.4+26.2
+itemlist_version=0.0.14+26.2

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/listeners/ChatListener.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/listeners/ChatListener.java
@@ -35,8 +35,8 @@ public class ChatListener {
                 if (ModernWarpMenu.getInstance().getSkyBlockConstantsManager().getSkyBlockConstants().warpMessages().warpFailMessages().containsKey(text)){
                     String failMessageKey = ModernWarpMenu.getInstance().getSkyBlockConstantsManager()
                             .getSkyBlockConstants().warpMessages().warpFailMessages().get(text);
-                    if (mc.screen != null && mc.screen instanceof ModernWarpScreen)
-                        ((ModernWarpScreen) mc.screen).onWarpFail(failMessageKey);
+                    if (mc.gui.screen() != null && mc.gui.screen() instanceof ModernWarpScreen)
+                        ((ModernWarpScreen) mc.gui.screen()).onWarpFail(failMessageKey);
                 }
             }
         });
@@ -63,9 +63,9 @@ public class ChatListener {
             }
         });*/
         ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
-            if (this.chatMessageSendDetected && client.screen instanceof ChatScreen && screen == null) {
+            if (this.chatMessageSendDetected && client.gui.screen() instanceof ChatScreen && screen == null) {
                 this.chatMessageSendDetected = false;
-                List<String> sentMessages = mc.gui.getChat().getRecentChat();
+                List<String> sentMessages = mc.gui.hud.getChat().getRecentChat();
                 if (!sentMessages.isEmpty()) {
                     checkChatMessageForReminder(sentMessages.getLast());
                 }

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/listeners/WarpMenuListener.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/listeners/WarpMenuListener.java
@@ -33,9 +33,9 @@ public class WarpMenuListener {
 
     public void registerEvents(){
         ClientTickEvents.START_CLIENT_TICK.register(client -> {
-            if (client.screen == null){
+            if (client.gui.screen() == null){
                 if (ModernWarpMenuState.isOpenConfigMenuRequested()){
-                    client.setScreen(SettingsManager.createSettingsScreen(null));
+                    client.gui.setScreen(SettingsManager.createSettingsScreen(null));
                     ModernWarpMenuState.setOpenConfigMenuRequested(false);
                 }
             }
@@ -54,9 +54,9 @@ public class WarpMenuListener {
             if (GameState.isOnSkyBlock() && screen instanceof ContainerScreen containerScreen){
                 Menu menu = GameCheckUtils.determineOpenMenu(containerScreen.getTitle());
                 if (menu == Menu.FAST_TRAVEL){
-                    minecraft.setScreen(new FastTravelScreen(containerScreen.getMenu(), Objects.requireNonNull(minecraft.player).getInventory(), ModernWarpMenuState.getOverworldLayout()));
+                    minecraft.gui.setScreen(new FastTravelScreen(containerScreen.getMenu(), Objects.requireNonNull(minecraft.player).getInventory(), ModernWarpMenuState.getOverworldLayout()));
                 }else if (menu == Menu.PORHTAL){
-                    minecraft.setScreen(new RiftFastTravelScreen(containerScreen.getMenu(), Objects.requireNonNull(minecraft.player).getInventory(), ModernWarpMenuState.getRiftLayout()));
+                    minecraft.gui.setScreen(new RiftFastTravelScreen(containerScreen.getMenu(), Objects.requireNonNull(minecraft.player).getInventory(), ModernWarpMenuState.getRiftLayout()));
                 }
             }
         });

--- a/src/main/java/com/github/yukkuritaku/modernwarpmenu/state/ModernWarpMenuState.java
+++ b/src/main/java/com/github/yukkuritaku/modernwarpmenu/state/ModernWarpMenuState.java
@@ -33,7 +33,7 @@ public class ModernWarpMenuState {
     }
 
     public static boolean isModernWarpMenuOpen() {
-        return Minecraft.getInstance().screen instanceof ModernWarpScreen;
+        return Minecraft.getInstance().gui.screen() instanceof ModernWarpScreen;
     }
 
     public static boolean isOpenConfigMenuRequested() {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,7 +40,7 @@
 	"accessWidener": "modernwarpmenu.classtweaker",
 	"depends": {
 		"fabricloader": ">=0.19.0",
-		"minecraft": "~26.1.2",
+		"minecraft": "~26.2",
 		"java": ">=21",
 		"fabric-api": "*",
 		"yet_another_config_lib_v3": "*"


### PR DESCRIPTION
- ChatListener.java

◦ mc.screen -> mc.gui.screen()
◦ mc.gui.getChat().getRecentChat() -> mc.gui.hud.getChat().getRecentChat()

- WarpMenuListener.java

◦ client.screen -> client.gui.screen()
◦ client.setScreen(...) -> client.gui.setScreen(...) ◦ minecraft.setScreen(...) -> minecraft.gui.setScreen(...)

- ModernWarpMenuState.java

◦ Minecraft.getInstance().screen -> Minecraft.getInstance().gui.screen()